### PR TITLE
Add failsafe to `cd`

### DIFF
--- a/app/civi_cron.sh
+++ b/app/civi_cron.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-cd /var/www/html
+cd /var/www/html || exit
 /usr/local/bin/drush civicrm-api -u 1 job.execute


### PR DESCRIPTION
`cd` can sometimes hang if `/var/www/html` doesn't exist and then it will do all of this in the wrong directory.